### PR TITLE
Fix bug causing order of parameters to get changed

### DIFF
--- a/R/functions.R
+++ b/R/functions.R
@@ -12,7 +12,7 @@ get_family <- function(D, family=NA) {
   # Select only the family paramaters
   family.id.parameters <- grep(family, D$Parameter)
   D.sub <- D[family.id.parameters,]
-  D.sub$Parameter <- factor(as.character(D.sub$Parameter))
+  D.sub$Parameter <- droplevels(D.sub$Parameter)
   # Copy the same attributes to the new object, except the number of
   # parameters
   # Probably there's a cleaner way to do it


### PR DESCRIPTION
I believe the goal here is to remove the unused levels of the factor. droplevels(D.sub$Parameter) should be used for this, because the use of factor(as.character(D.sub$Parameter)) was causing the existing ordering of the levels of Parameter to be lost and to be replaced with a purely alphabetical ordering. This was leading to "x[10]" coming before "x[2]" for example. As a result, in parameters were in the wrong order in many of the ggs_ plotting functions if the "family" option was used.
