### PR TITLE
Upgrade ggpairs example

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,8 +11,9 @@ Author: Xavier Fernández i Marín <xavier.fim@gmail.com>
 Depends:
     dplyr,
     tidyr (>= 0.3.1),
-    ggplot2, 
-    GGally
+    ggplot2
+Imports:
+  GGally (> 0.5.0)
 Suggests:
     coda
 License: GPL-2

--- a/R/ggs_pairs.R
+++ b/R/ggs_pairs.R
@@ -9,6 +9,7 @@
 #' @export
 #' @importFrom GGally ggpairs
 #' @examples
+#' library(GGally)
 #' data(linear)
 #'
 #' # default ggpairs plot

--- a/R/ggs_pairs.R
+++ b/R/ggs_pairs.R
@@ -3,32 +3,32 @@
 #' Pairs style plots to evaluate posterior correlations among parameters.
 #'
 #' @param D Data frame with the simulations.
-#' @param family Name of the family of parameters to plot, as given by a character vector or a regular expression. A family of parameters is considered to be any group of parameters with the same name but different numerical value between square brackets (as beta[1], beta[2], etc). 
+#' @param family Name of the family of parameters to plot, as given by a character vector or a regular expression. A family of parameters is considered to be any group of parameters with the same name but different numerical value between square brackets (as beta[1], beta[2], etc).
 #' @param ... Arguments to be passed to \code{ggpairs}, including geom's \code{aes} (see examples)
 #' @return A \code{ggpairs} object that creates a plot matrix consisting of univariate density plots on the diagonal, correlation estimates in upper triangular elements, and scatterplots in lower triangular elements.
 #' @export
 #' @importFrom GGally ggpairs
 #' @examples
 #' data(linear)
-#' 
+#'
 #' # default ggpairs plot
 #' ggs_pairs(ggs(s))
-#' 
+#'
 #' # change alpha transparency of points
 #' ggs_pairs(ggs(s), lower=list(params=c(alpha=.2)))
-#' 
+#'
 #' # with too many points, try contours instead
 #' ggs_pairs(ggs(s), lower=list(continuous="density"))
-#' 
-#' # histograms instead of univariate densities on diagonal 
+#'
+#' # histograms instead of univariate densities on diagonal
 #' ggs_pairs(ggs(s), diag=list(continuous="bar"))
-#' 
+#'
 #' # coloring results according to chains
 #' ggs_pairs(ggs(s), color="Chain")
-#' 
+#'
 #' # custom points on lower panels, black contours on upper panels
-#' ggs_pairs(ggs(s), 
-#'   upper=list(continuous="density", params=c(color="black")), 
+#' ggs_pairs(ggs(s),
+#'   upper=list(continuous="density", params=c(color="black")),
 #'   lower=list(params=c(alpha=.2, shape=1)))
 ggs_pairs <- function(D, family=NA, ...) {
   # Manage subsetting a family of parameters
@@ -46,8 +46,8 @@ ggs_pairs <- function(D, family=NA, ...) {
   D_wide$Chain <- factor(D_wide$Chain)
   par_cols <- !(bracket_names %in% c("Iteration", "Chain"))
   # Plot
-  f <- ggpairs(D_wide, 
-    columnLabels = bracket_names[par_cols], 
+  f <- ggpairs(D_wide,
+    columnLabels = bracket_names[par_cols],
     columns = which(par_cols), ...)
   return(f)
 }

--- a/R/ggs_pairs.R
+++ b/R/ggs_pairs.R
@@ -15,21 +15,21 @@
 #' ggs_pairs(ggs(s))
 #'
 #' # change alpha transparency of points
-#' ggs_pairs(ggs(s), lower=list(params=c(alpha=.2)))
+#' ggs_pairs(ggs(s), lower=list(continuous = wrap("points", alpha = 0.2)))
 #'
 #' # with too many points, try contours instead
 #' ggs_pairs(ggs(s), lower=list(continuous="density"))
 #'
 #' # histograms instead of univariate densities on diagonal
-#' ggs_pairs(ggs(s), diag=list(continuous="bar"))
+#' ggs_pairs(ggs(s), diag=list(continuous="barDiag"))
 #'
 #' # coloring results according to chains
-#' ggs_pairs(ggs(s), color="Chain")
+#' ggs_pairs(ggs(s), mapping = aes(color = Chain))
 #'
 #' # custom points on lower panels, black contours on upper panels
 #' ggs_pairs(ggs(s),
-#'   upper=list(continuous="density", params=c(color="black")),
-#'   lower=list(params=c(alpha=.2, shape=1)))
+#'   upper=list(continuous = wrap("density", color = "black")),
+#'   lower=list(continuous = wrap("points", alpha = 0.2, shape = 1)))
 ggs_pairs <- function(D, family=NA, ...) {
   # Manage subsetting a family of parameters
   if (!is.na(family)) {

--- a/man/ggs_pairs.Rd
+++ b/man/ggs_pairs.Rd
@@ -20,6 +20,7 @@ A \code{ggpairs} object that creates a plot matrix consisting of univariate dens
 Pairs style plots to evaluate posterior correlations among parameters.
 }
 \examples{
+library(GGally)
 data(linear)
 
 # default ggpairs plot

--- a/man/ggs_pairs.Rd
+++ b/man/ggs_pairs.Rd
@@ -26,20 +26,20 @@ data(linear)
 ggs_pairs(ggs(s))
 
 # change alpha transparency of points
-ggs_pairs(ggs(s), lower=list(params=c(alpha=.2)))
+ggs_pairs(ggs(s), lower=list(continuous = wrap("points", alpha = 0.2)))
 
 # with too many points, try contours instead
 ggs_pairs(ggs(s), lower=list(continuous="density"))
 
 # histograms instead of univariate densities on diagonal
-ggs_pairs(ggs(s), diag=list(continuous="bar"))
+ggs_pairs(ggs(s), diag=list(continuous="barDiag"))
 
 # coloring results according to chains
-ggs_pairs(ggs(s), color="Chain")
+ggs_pairs(ggs(s), mapping = aes(color = Chain))
 
 # custom points on lower panels, black contours on upper panels
 ggs_pairs(ggs(s),
-  upper=list(continuous="density", params=c(color="black")),
-  lower=list(params=c(alpha=.2, shape=1)))
+  upper=list(continuous = wrap("density", color = "black")),
+  lower=list(continuous = wrap("points", alpha = 0.2, shape = 1)))
 }
 


### PR DESCRIPTION
Hi @xfim,

Here's a pull request to fix the ggs_pairs example.  

I moved the GGally into imports, as you only import / need ggpairs.  You already had the import statement in place, so it should have no impact.  The CRAN people love to import vs. depend.

Quick note: 
* checking examples ... OK
Examples with CPU or elapsed time > 5s
           user system elapsed
ggs_pairs 8.917  0.163   9.420

The example takes longer than 5 seconds. If it's just one, they might let it slide, but they get mad at me. :-/ .  To get around this, I store the plotmatrix to a variable, then I comment the variable on the next line. 

Hope this helps!

Best,
Barret