### PR TITLE
Fix: Error in ggs_geweke from 0-var check in sde0f function

### DIFF
--- a/R/functions.R
+++ b/R/functions.R
@@ -36,7 +36,8 @@ get_family <- function(D, family=NA) {
 #' @export
 sde0f <- function(x) {
   # In case of series not varying, set v0 to 0
-  if (length(unique(x))>1) {
+  # if (length(unique(x))>1) {
+  if (0 != var(if (is.factor(x)) as.integer(x) else x)) {    
     m.ar <- ar(x)
     v0 <- m.ar$var.pred / (1-sum(m.ar$ar))^2
   } else {


### PR DESCRIPTION
Hello,

I wrote and maintain a package that depends on `ggmcmc` ([MixSIAR](https://github.com/brianstock/MixSIAR)). In one of my updates, I encountered an error stemming from `ggs_geweke`, which I traced to `sde0f`.

The error was surprising, because it occurred for a JAGS model with an informative prior, but NOT for the same model with the same data using an uninformative prior. My guess is the issue occurs for a parameter with *nearly* 0 variance. Your check for 0 variance in `sde0f` was `length(unique(x)) > 0`, but an alternative [solution from Stack Overflow](https://stackoverflow.com/questions/8805298/quickly-remove-zero-variance-variables-from-a-data-frame) seems more robust in my case:

```
0 != var(if (is.factor(x)) as.integer(x) else x)
```

When I make this change to `sde0f` I get no errors with `ggs_geweke` for either model.