### PR TITLE
make source of n() explicit for dplyr >= 1.0

### DIFF
--- a/R/ggs_geweke.R
+++ b/R/ggs_geweke.R
@@ -40,7 +40,7 @@ ggs_geweke <- function(D, family=NA, frac1=0.1, frac2=0.5, shadow_limit=TRUE, gr
   # Compute means, spectral densities and N's
   D.geweke <- D.geweke %>%
     dplyr::group_by (Parameter, Chain, part) %>%
-    dplyr::summarize(m=mean(value), sde0f=sde0f(value), n=n())
+    dplyr::summarize(m=mean(value), sde0f=sde0f(value), n=dplyr::n())
   # Calculate separately the means and variances
   M <- D.geweke %>%
     dplyr::select(-sde0f, -n) %>%


### PR DESCRIPTION
`ggs_geweke()` sometimes (always?) runs into this error if dplyr 1.0 is installed:

```
<error/dplyr_error>
Problem with `summarise()` input `n`.
x could not find function "n"
i Input `n` is `n()`.
i The error occured in group 1: Parameter = "deviance", Chain = 1, part = "first".
Backtrace:
  1. MixSIAR::output_JAGS(jags.uninf, mix, source)
  2. ggmcmc::ggmcmc(...)
  4. ggmcmc::ggs_geweke(D)
  4. dplyr::group_by(., Parameter, Chain, part)
 12. dplyr::summarize(., m = mean(value), sde0f = sde0f(value), n = n())
 15. dplyr:::summarise_cols(.data, ...)
```

This is because of this breaking change in dplyr 1.0: https://github.com/tidyverse/dplyr/pull/4918

This PR makes the source of n() explicit and fixes the issue.