### PR TITLE
specify stats package for ar function

### DIFF
--- a/R/functions.R
+++ b/R/functions.R
@@ -38,7 +38,7 @@ sde0f <- function(x) {
   # In case of series not varying, set v0 to 0
   # if (length(unique(x))>1) {
   if (0 != var(if (is.factor(x)) as.integer(x) else x)) {
-    m.ar <- ar(x)
+    m.ar <- stats::ar(x)
     v0 <- m.ar$var.pred / (1-sum(m.ar$ar))^2
   } else {
     v0 <- 0


### PR DESCRIPTION
`brms` also contains an `ar` function, and is a package commonly loaded with `ggmcmc`, so this avoids errors when calling `sde0f`.